### PR TITLE
fix: Check if variable exists

### DIFF
--- a/resources/views/meta.blade.php
+++ b/resources/views/meta.blade.php
@@ -28,7 +28,7 @@
   <meta name="auth_endpoint" content="{{ \Coreproc\NovaEcho\NovaEcho::config('auth_endpoint') }}">
 @endif
 
-@if(method_exists(request()->user(), 'receivesBroadcastNotificationsOn'))
+@if(!empty(request()->user()) && method_exists(request()->user(), 'receivesBroadcastNotificationsOn'))
   <meta name="user_private_channel" content="{{ request()->user()->receivesBroadcastNotificationsOn() }}">
 @else
   <meta name="user_private_channel" content="{{ str_replace('\\', '.', get_class(request()->user())).'.'.request()->user()->id }}">


### PR DESCRIPTION
**Background**

Argument #1 ($object_or_class) must be of type object|string, null given (View: /home/1011020.cloudwaysapps.com/qpzsrrxzrd/public_html/vendor/coreproc/nova-echo/resources/views/meta.blade.php

**Changes**

- PHP 7.4 to 8.0 breaking change is the `method_exists` function is typed, with the first param needing to be either an `object|string`, which will throw an error if passing null (previously did not)